### PR TITLE
Fix tuple handling in deepCopy

### DIFF
--- a/Resources/CeciliaLib.py
+++ b/Resources/CeciliaLib.py
@@ -828,10 +828,9 @@ def deepCopy(ori):
         new = []
         for data in ori:
             new.append(deepCopy(data))
-        return new
+        return tuple(new)
     else:
         return ori
-    return new
 
 ###### Conversion functions #######
 def interpFloat(t, v1, v2):


### PR DESCRIPTION
## Summary
- fix `deepCopy` so tuples are returned as tuples

## Testing
- `python -m py_compile $(find Resources -name '*.py') Cecilia5.py setup.py`

------
https://chatgpt.com/codex/tasks/task_e_68631693922c832c9fef2bafc1ad7fa9